### PR TITLE
Ensure content transitions are smooth by default, and allow for easier animation customization

### DIFF
--- a/src/wtc-modal-view.js
+++ b/src/wtc-modal-view.js
@@ -29,6 +29,7 @@ class Modal {
     this.classNameOpen = "modal--open";
     this.appended = false;
     this.storeContent = false;
+    this.inOutDuration = 400;
 
     // getters and setters variables
     this._onOpen = null;
@@ -110,7 +111,7 @@ class Modal {
         // This prevents the content from stil being tabbable in the DOM.
         if (this.storeContent) this.wrapperOfContent.appendChild(this._content);
         else this.modalContent.innerHTML = "";
-      }, 500);
+      }, this.inOutDuration);
 
       if (Modal.hash)
         history.replaceState("", document.title, window.location.pathname);

--- a/src/wtc-modal-view.js
+++ b/src/wtc-modal-view.js
@@ -85,13 +85,6 @@ class Modal {
     if (this.state) {
       this.modal.classList.remove(this.classNameOpen);
 
-      if (this.optionalClass) {
-        if (typeof this.optionalClass === "string")
-          this.modal.classList.remove(this.optionalClass);
-        else if (this.optionalClass instanceof Array)
-          this.modal.classList.remove(...this.optionalClass);
-      }
-
       // if a focusOnClose element was passed in when the modal opened, focus it!
       if (this.focusOnClose) this.focusOnClose.focus();
 
@@ -101,7 +94,19 @@ class Modal {
         // Setting the modal to display: none; when closed, just to prevent anything from still being
         // focussable. Mainly the close button.
         this.modal.style.display = "none";
-        // On close, we taken the content from the modal and apply it to our static modal wrapper.
+
+        // We only remove the optional classNames when the timeout is complete,
+        // and everything is "gone" from view.
+        // This way, we're able to target our various custom modals in CSS,
+        // via their specific classNames (i.e. ".modal--video", ".modal--video.modal--open"):
+        if (this.optionalClass) {
+          if (typeof this.optionalClass === "string")
+            this.modal.classList.remove(this.optionalClass);
+          else if (this.optionalClass instanceof Array)
+            this.modal.classList.remove(...this.optionalClass);
+        }
+
+        // On close, we take the content from the modal and apply it to our static modal wrapper.
         // This prevents the content from stil being tabbable in the DOM.
         if (this.storeContent) this.wrapperOfContent.appendChild(this._content);
         else this.modalContent.innerHTML = "";

--- a/src/wtc-modal-view.scss
+++ b/src/wtc-modal-view.scss
@@ -3,6 +3,8 @@
 }
 
 .modal {
+  --fade-duration: 0.4s;
+    
   display: block;
   height: 100%;
   left: 0;
@@ -10,7 +12,7 @@
   pointer-events: none;
   position: fixed;
   top: 0;
-  transition: opacity 0s linear 0.4s;
+  transition: opacity 0s linear var(--fade-duration);
   width: 100%;
 }
 
@@ -19,12 +21,9 @@
   pointer-events: auto;
   transition-delay: 0s;
 
-  .modal__content {
-    display: block;
-  }
-
   .modal__overlay,
-  .modal__close {
+  .modal__close,
+  .modal__content {
     opacity: 1;
   }
 }
@@ -34,7 +33,7 @@
   height: 100%;
   opacity: 0;
   position: absolute;
-  transition: opacity 0.3s ease;
+  transition: opacity var(--fade-duration) ease;
   width: 100%;
 }
 
@@ -54,12 +53,13 @@
   display: block;
   margin: 0 0 10px auto;
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity var(--fade-duration) ease;
 }
 
 .modal__content {
   background: white;
-  display: none;
+  opacity: 0;
+  transition: opacity var(--fade-duration) ease;
 }
 
 .modal__focus-start,

--- a/src/wtc-modal-view.scss
+++ b/src/wtc-modal-view.scss
@@ -3,7 +3,7 @@
 }
 
 .modal {
-  --fade-duration: 0.4s;
+  --in-out-duration: 0.4s;
     
   display: block;
   height: 100%;
@@ -12,7 +12,7 @@
   pointer-events: none;
   position: fixed;
   top: 0;
-  transition: opacity 0s linear var(--fade-duration);
+  transition: opacity 0s linear var(--in-out-duration);
   width: 100%;
 }
 
@@ -33,7 +33,7 @@
   height: 100%;
   opacity: 0;
   position: absolute;
-  transition: opacity var(--fade-duration) ease;
+  transition: opacity var(--in-out-duration) ease;
   width: 100%;
 }
 
@@ -53,13 +53,13 @@
   display: block;
   margin: 0 0 10px auto;
   opacity: 0;
-  transition: opacity var(--fade-duration) ease;
+  transition: opacity var(--in-out-duration) ease;
 }
 
 .modal__content {
   background: white;
   opacity: 0;
-  transition: opacity var(--fade-duration) ease;
+  transition: opacity var(--in-out-duration) ease;
 }
 
 .modal__focus-start,


### PR DESCRIPTION
## The issue
We currently rely on CSS to toggle visibility of the `.modal__content`, with a simple `display: none`/`display: block` toggle, based on whether or not the modal has a className of `.modal--open`. This becomes an issue, because the `"modal--open"` className gets removed instantly on close of a modal.

## The solution
Rather than introducing breaking changes and adjusting when that `"modal--open"` class is removed, I've:
- Changed the CSS so that the `display: none/block` toggle is an `opacity` transition instead.
  - This does not have any accessibility implications, since the parent `.modal` element still does that same toggle.
- Added the removal of `instance.optionalClassName` to the `setTimeout` that occurs on close.
  - This is more of a developer experience update. It allows us to maintain our custom styling (on, for example, a custom `.modal--video` selector) for an extra bit of time, allowing us to put a custom CSS exit transition based on the `.modal--open` class (which is still removed instantly).

## Demo
Un-comment lines `15–16` on `index.js` to see custom behaviour. And take a look at `main.scss` to see how easy it is to add that custom behaviour:
https://codepen.io/team/wtc/project/editor/15c2edf11d26577348ddfc2615d3fdf6

## Extra
Updated the modal close `setTimeout` duration argument to pull from a new `instance.inOutDuration` property, rather than being a hard-coded value. This way, you can change how long it takes for your modal to open and—more importantly now—close. This defaults to `400`, and can be adjusted to match your custom CSS styles.

⚠️ Note: I tried doing this ^ with a single CSS custom property, and pulling that in via the JS (so there's only one source of truth), but since there's no `.modal` div in the DOM to begin with, we can only read CSS props on it after it has been appended to the DOM (not on first open).

---
Btw, this will close #15 , albeit in a different manner.